### PR TITLE
Tools: reserve 2 board ID numbers for periph hardware

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -265,6 +265,9 @@ AP_HW_VIMDRONES_MOSAIC_X5            1405
 AP_HW_VIMDRONES_MOSAIC_H             1406
 AP_HW_VIMDRONES_PERIPH               1407
 
+AP_HW_PIXHAWK1_PERIPH                1408
+AP_HW_PIXHAWK1-1M_PERIPH             1409
+
 # IDs 5000-5099 reserved for Carbonix
 # IDs 5200-5209 reserved for Airvolute
 AP_HW_AIRVOLUTE_DCS2             5200


### PR DESCRIPTION
This reserves two board ID number for pixhawk1 periph hardware